### PR TITLE
Adding traceroute and ping service by default to all hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You should install logrotate for docker container log
 
 /etc/logrotate.d/docker-container
 ```
-/docker/containers/*/*.log {
+/var/lib/docker/containers/*/*.log {
   rotate 7
   daily
   compress

--- a/api/mccache.js
+++ b/api/mccache.js
@@ -63,7 +63,7 @@ function create_hostrec(service, uri, cb) {
         var rec = {
             info: get_hostinfo(host),
             communities: host['group-communities']||[],
-            services: [],
+            services: [{type: "traceroute"}, {type: "ping"}],
 
             //TODO .. I am not sure what we can do with host-administrators
             //host['host-administrators'],
@@ -177,7 +177,7 @@ function cache_ls(hosts, ls, lsid, cb) {
                     //"https://192.12.15.111/services/MP/OWAMP",
                     //"https://[2620:0:210:1::111]/services/MP/OWAMP"
                     //],
-                    var len = service['service-locator'].length;
+                    //var len = service['service-locator'].length;
                     //var locator = service['service-locator'][len-1];
 
                     //construct service record

--- a/api/pub/meshconfig.js
+++ b/api/pub/meshconfig.js
@@ -319,7 +319,7 @@ function generate_group_members( test, group, type, host_groups, host_catalog, n
 
         set_test_meta( test, "_hostgroup", test.name );
         set_test_meta( test, "_test", test.name );
-        set_test_meta( test, "_tool", convert_tool( test.testspec.specs.tool ));
+        //set_test_meta( test, "_tool", convert_tool( test.testspec.specs.tool ));
 
         if(err) return next(err);
         test[ group_field ] = hosts;

--- a/ui/js/config.js
+++ b/ui/js/config.js
@@ -1,9 +1,9 @@
 
 app.controller('ConfigsController',
-function($scope, appconf, toaster, $http, $location, scaMessage, users, hosts, hostgroups, configs, $routeParams, testspecs, uiGmapGoogleMapApi) {
+function($scope, appconf, toaster, $http, $location, scaMessage, users, hosts, hostgroups, configs, $routeParams, testspecs, uiGmapGoogleMapApi, $timeout) {
     scaMessage.show(toaster);
     $scope.active_menu = "configs";
-    //$scope.importer_url = "";
+    $scope.show_map = false;
 
     //start loading things (should I parallelize)
     users.getAll().then(function(_users) {
@@ -25,6 +25,12 @@ function($scope, appconf, toaster, $http, $location, scaMessage, users, hosts, h
                         //select first one
                         if($scope.configs.length > 0) $scope.select($scope.configs[0]);
                     }
+
+		    //delay showing map slightly to prevent gmap to miss resize event?
+		    //TODO - figure out what's going on with gmap and fix it instead of this hack..
+		    $timeout(()=>{
+			$scope.show_map = true;
+		    });
                 });
             });
         });
@@ -42,12 +48,6 @@ function($scope, appconf, toaster, $http, $location, scaMessage, users, hosts, h
         $location.update_path("/configs/"+config._id);
         window.scrollTo(0,0);
     }
-
-    /*
-    $scope.$watchCollection('selected.config', function() {
-        console.log("config changed");
-    });
-    */
 
     function reset_map(test) {
         test.map = {

--- a/ui/t/configs.html
+++ b/ui/t/configs.html
@@ -148,6 +148,7 @@
                     <div class="col-sm-10">
                         <ul class="list-group" ng-if="selected.tests.length > 0">
                             <li class="list-group-item" ng-repeat="test in selected.tests" ng-class="{disabled: !test.enabled, 'slide-down': !test._id}">
+				{{show_map}}
                                 <ng-include src="'t/testeditor.html'"></ng-include>
                             </li>
                         </ul>

--- a/ui/t/configs.html
+++ b/ui/t/configs.html
@@ -148,7 +148,6 @@
                     <div class="col-sm-10">
                         <ul class="list-group" ng-if="selected.tests.length > 0">
                             <li class="list-group-item" ng-repeat="test in selected.tests" ng-class="{disabled: !test.enabled, 'slide-down': !test._id}">
-				{{show_map}}
                                 <ng-include src="'t/testeditor.html'"></ng-include>
                             </li>
                         </ul>

--- a/ui/t/testeditor.html
+++ b/ui/t/testeditor.html
@@ -39,7 +39,7 @@
 
 <div class="form-group">
     <label class="col-sm-2 control-label"></label>
-    <div class="col-sm-10">
+    <div class="col-sm-10" ng-if="show_map">
         <ui-gmap-google-map center="test.map.center" zoom="test.map.zoom" options="test.map.options">
             <ui-gmap-markers fit="true" models="test.map.markers" coords="'self'" icon="'icon'"></ui-gmap-markers>
         </ui-gmap-google-map>


### PR DESCRIPTION
Ref https://github.com/perfsonar/meshconfig-admin/issues/38

mccache will insert traceroute and ping service by default. 

I also patched the issue of google map sometimes not properly initialized, but I wouldn't call this a proper fix.. We should find the root cause and fix it in more proper way.

I've also commented out set_test_meta() which uses testspec that may not be yet resolved at the time of invocation. generate_group_members() is incomprehensible, and it should be cleaned up.
